### PR TITLE
 Fix: prevent invalid room capacity and empty room name

### DIFF
--- a/FPT_Cinema-main/FPT_Cinema-main/src/java/Controllers/AdminEditRoom.java
+++ b/FPT_Cinema-main/FPT_Cinema-main/src/java/Controllers/AdminEditRoom.java
@@ -73,7 +73,16 @@ public class AdminEditRoom extends HttpServlet {
         String name = request.getParameter("name");
         int capacity = Integer.parseInt(request.getParameter("capacity"));
         PrintWriter out = response.getWriter();
-   
+        if(name == null || name.trim().isEmpty()) {
+    request.setAttribute("error", "Name cannot be empty");
+    doGet(request, response);
+    return;
+}
+        if (capacity <= 0) {
+    request.setAttribute("error", "Capacity must be greater than 0");
+    doGet(request, response);
+    return;
+}
         Object iu = request.getParameter("btnInUp");
         boolean checkUpdate = false;
         for (Room r : RoomDAO.INSTANCE.getListRoom()) {


### PR DESCRIPTION
Fixes #1

Added validation to prevent:
- negative or zero room capacity
- empty room name

This ensures proper validation for room data.